### PR TITLE
Feature/notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,34 +30,37 @@ cdk synth --context num_users=30
 As the same as `cdk synth` above, you can specify the number of attendees (the number of IAM Users or Braket Notebooks). 
 You have to specify the initial password for IAM Users (this would be updated on the initial login). 
 
-##### 3.1. Which stacks to deploy
-###### 3.1.a. Only deploying IAM stack
 ```
 cdk deploy braket-workshop-iam \
     --context num_users=30 \
     --parameters DefaultUserPassword="Braket@2020"
 ```
-
-###### 3.1.b. Deploying all the stacks including Braket Notebooks in 3 AWS Regions
-```
-cdk deploy --all \
-    --context num_users=30 \
-    --parameters braket-workshop-iam:DefaultUserPassword="Braket@2020"
-```
-
-##### 3.2. Enable QPU
-By default, QPUs are disabled to avoid unexpected billing in the hands-on workshop. To try QPU, you can allow access by adding a `disable_qpu=false` context:  
-```
-cdk deploy --all \
-    --context num_users=30 \
-    --context disable_qpu=false \
-    --parameters braket-workshop-iam:DefaultUserPassword="Braket@2020"
-```
-
 Wait until the CloudFormation stack became `CREATE_COMPLETE`. The deployment of the IAM stack takes roughly 3 minuites.
 
 Check your AWS Account ID (12-digit numbers) or Alias to create a sign-in URL for participants: 
 https://*account-ID-or-alias*.signin.aws.amazon.com/console
+
+##### Deployment options 
+###### Enable QPU
+By default, QPUs are disabled to avoid unexpected billing in the hands-on workshop. To try QPU, you can allow access by adding a `disable_qpu=false` context:  
+```
+cdk deploy braket-workshop-iam \
+    --context num_users=30 \
+    --context disable_qpu=false \
+    --parameters DefaultUserPassword="Braket@2020"
+```
+
+###### Deploying all the stacks including Braket Notebooks in 3 AWS Regions
+```
+cdk deploy --all \
+    --context num_users=30 \
+    --parameters braket-workshop-iam:DefaultUserPassword="Braket@2020"
+```
+
+##### 4. Clean up 
+```
+cdk destroy --all
+```
 
 ### How to login (for Participants)
 Workshop admin will provide 3 informations: 

--- a/README.md
+++ b/README.md
@@ -33,21 +33,28 @@ You have to specify the initial password for IAM Users (this would be updated on
 ##### 3.1. Which stacks to deploy
 ###### 3.1.a. Only deploying IAM stack
 ```
-cdk deploy BraketWorkshopIAMStack --context num_users=30 --parameters DefaultUserPassword="InitialPassword4IAMUser"
+cdk deploy braket-workshop-iam \
+    --context num_users=30 \
+    --parameters DefaultUserPassword="Braket@2020"
 ```
 
-###### 3.1.b. Deploying all the stacks including Braket Notebooks
+###### 3.1.b. Deploying all the stacks including Braket Notebooks in 3 AWS Regions
 ```
-cdk deploy --all --context num_users=30 --parameters BraketWorkshopIAMStack:DefaultUserPassword="InitialPassword4IAMUser"
+cdk deploy --all \
+    --context num_users=30 \
+    --parameters braket-workshop-iam:DefaultUserPassword="Braket@2020"
 ```
 
 ##### 3.2. Enable QPU
-By default, QPUs are disabled to avoid unexpected billing in the hands-on workshop. To try QPU, you can enable by adding a `disable_qpu=false` context:  
+By default, QPUs are disabled to avoid unexpected billing in the hands-on workshop. To try QPU, you can allow access by adding a `disable_qpu=false` context:  
 ```
-cdk deploy BraketWorkshopIAMStack --context num_users=30 --context disable_qpu=false --parameters DefaultUserPassword="InitialPassword4IAMUser"
+cdk deploy --all \
+    --context num_users=30 \
+    --context disable_qpu=false \
+    --parameters braket-workshop-iam:DefaultUserPassword="Braket@2020"
 ```
 
-Wait until the CloudFormation stack became `CREATE_COMPLETE`. The deployment itself takes roughly 3 minuites.
+Wait until the CloudFormation stack became `CREATE_COMPLETE`. The deployment of the IAM stack takes roughly 3 minuites.
 
 Check your AWS Account ID (12-digit numbers) or Alias to create a sign-in URL for participants: 
 https://*account-ID-or-alias*.signin.aws.amazon.com/console

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This is a CDK app which creates IAM User and IAM Role for Amazon Braket Hands-on
 ## Usage
 
 ### How to deploy (for Admin)
-From you favorite environment (e.g., AWS CloudShell or AWS Cloud9), 
+From you favorite environment (e.g., AWS CloudShell or AWS Cloud9), run commands below. 
+
+#### 1. Setting up the CDK environment
 
 ```
 sudo npm install -g aws-cdk
@@ -16,8 +18,33 @@ cd amazon-braket-workshop-cdk/
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-cdk synth
-cdk deploy braket-workshop-cdk
+```
+
+#### 2. (Optional) Synthesize into CloudFormation templates 
+You can specify the number of attendees (the number of IAM Users or Braket Notebooks). 
+```
+cdk synth --context num_users=30
+```
+
+#### 3. Deploy stack(s)
+As the same as `cdk synth` above, you can specify the number of attendees (the number of IAM Users or Braket Notebooks). 
+You have to specify the initial password for IAM Users (this would be updated on the initial login). 
+
+##### 3.1. Which stacks to deploy
+###### 3.1.a. Only deploying IAM stack
+```
+cdk deploy BraketWorkshopIAMStack --context num_users=30 --parameters DefaultUserPassword="InitialPassword4IAMUser"
+```
+
+###### 3.1.b. Deploying all the stacks including Braket Notebooks
+```
+cdk deploy --all --context num_users=30 --parameters BraketWorkshopIAMStack:DefaultUserPassword="InitialPassword4IAMUser"
+```
+
+##### 3.2. Enable QPU
+By default, QPUs are disabled to avoid unexpected billing in the hands-on workshop. To try QPU, you can enable by adding a `disable_qpu=false` context:  
+```
+cdk deploy BraketWorkshopIAMStack --context num_users=30 --context disable_qpu=false --parameters DefaultUserPassword="InitialPassword4IAMUser"
 ```
 
 Wait until the CloudFormation stack became `CREATE_COMPLETE`. The deployment itself takes roughly 3 minuites.

--- a/app.py
+++ b/app.py
@@ -2,10 +2,16 @@
 
 from aws_cdk import core
 
-from braket_workshop_cdk.braket_workshop_cdk_stack import BraketWorkshopIAMStack
+from braket_workshop_cdk.braket_workshop_cdk_stack import BraketWorkshopIAMStack, BraketWorkshopNotebookStack
 
 
 app = core.App()
-BraketWorkshopIAMStack(app, "braket-workshop-cdk", env={'region': 'us-west-2'})
+iam_stack = BraketWorkshopIAMStack(app, "braket-workshop-iam", env={'region': 'us-west-2'})
+
+notebook_role_arn = iam_stack.braket_notebook_role.role_arn
+
+BraketWorkshopNotebookStack(app, "braket-workshop-notebook-us-east-1", notebook_role_arn=notebook_role_arn, partition_remainder=0, env={'region': 'us-east-1'})
+BraketWorkshopNotebookStack(app, "braket-workshop-notebook-us-west-1", notebook_role_arn=notebook_role_arn, partition_remainder=1, env={'region': 'us-west-1'})
+BraketWorkshopNotebookStack(app, "braket-workshop-notebook-us-west-2", notebook_role_arn=notebook_role_arn, partition_remainder=2, env={'region': 'us-west-2'})
 
 app.synth()

--- a/app.py
+++ b/app.py
@@ -2,10 +2,10 @@
 
 from aws_cdk import core
 
-from braket_workshop_cdk.braket_workshop_cdk_stack import BraketWorkshopCdkStack
+from braket_workshop_cdk.braket_workshop_cdk_stack import BraketWorkshopIAMStack
 
 
 app = core.App()
-BraketWorkshopCdkStack(app, "braket-workshop-cdk", env={'region': 'us-west-2'})
+BraketWorkshopIAMStack(app, "braket-workshop-cdk", env={'region': 'us-west-2'})
 
 app.synth()

--- a/braket_workshop_cdk/braket_workshop_cdk_stack.py
+++ b/braket_workshop_cdk/braket_workshop_cdk_stack.py
@@ -25,7 +25,7 @@ class BraketWorkshopNotebookStack(core.Stack):
         super().__init__(scope, construct_id, **kwargs)
         
         braket_notebook_life_cycle_config = sagemaker.CfnNotebookInstanceLifecycleConfig(
-            self, "BraketNotebookInstanceLifecycleConfigOnStart", 
+            self, "braket-notebook-instance-lifecycle-config", 
             on_start=[{"content": life_cycle_config_script}]
             )
         

--- a/braket_workshop_cdk/braket_workshop_cdk_stack.py
+++ b/braket_workshop_cdk/braket_workshop_cdk_stack.py
@@ -197,7 +197,7 @@ class BraketWorkshopIAMStack(core.Stack):
         )
         
         braket_disable_qpu_deny_create_task = iam.PolicyStatement(
-            sid="ExplicitDenyCreateQuantumTask", 
+            sid="ExplicitDenyBraketQPUCreateQuantumTask", 
             effect=iam.Effect.DENY, 
             actions=[
                 "braket:CreateQuantumTask"
@@ -209,12 +209,15 @@ class BraketWorkshopIAMStack(core.Stack):
         braket_disable_qpu_policy_doc.add_statements(braket_disable_qpu_allow_read_only_resources)
         braket_disable_qpu_policy_doc.add_statements(braket_disable_qpu_deny_create_task)
         
-        disable_qpu = bool(self.node.try_get_context("disable_qpu"))
+        # Create a Disable QPU Policy to the IAM Role
+        braket_disable_qpu_policy = iam.Policy(
+            self, id="AmazonBraketDisableQPUPolicy", 
+            document=braket_disable_qpu_policy_doc, 
+            policy_name="AmazonBraketDisableQPUPolicy"
+        )
+        
+        
+        from distutils.util import strtobool
+        disable_qpu = strtobool(self.node.try_get_context("disable_qpu"))
         if disable_qpu: 
-            # Attatch the Disable QPU Policy to the IAM Role
-            braket_disable_qpu_policy = iam.Policy(
-                self, id="AmazonBraketDisableQPUPolicy", 
-                document=braket_disable_qpu_policy_doc, 
-                roles=[braket_notebook_role], 
-                policy_name="AmazonBraketDisableQPUPolicy"
-            )
+            braket_disable_qpu_policy.attatchToRoles(braket_notebook_role)

--- a/braket_workshop_cdk/braket_workshop_cdk_stack.py
+++ b/braket_workshop_cdk/braket_workshop_cdk_stack.py
@@ -5,7 +5,7 @@ from aws_cdk import (
 )
 
 
-class BraketWorkshopCdkStack(core.Stack):
+class BraketWorkshopIAMStack(core.Stack):
     
     def __init__(self, scope: core.Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -73,7 +73,8 @@ class BraketWorkshopCdkStack(core.Stack):
             no_echo=True
         )
         
-        for i in range(30): 
+        num_users = int(self.node.try_get_context("num_users"))
+        for i in range(num_users): 
             iam_user = iam.User(
                 self, f"WorkshopUser{i}", 
                 user_name=f"WorkshopUser-{i}", 

--- a/cdk.json
+++ b/cdk.json
@@ -13,6 +13,7 @@
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
     "@aws-cdk/aws-efs:defaultEncryptionAtRest": true, 
     
-    "num_users": "30"
+    "num_users": "30", 
+    "disable_qpu": "true"
   }
 }

--- a/cdk.json
+++ b/cdk.json
@@ -11,6 +11,8 @@
     "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
     "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true
+    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true, 
+    
+    "num_users": "30"
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as fp:
 
 setuptools.setup(
     name="braket_workshop_cdk",
-    version="0.0.2",
+    version="0.0.3",
 
     description="A CDK Python app to create IAM User/Role for Amazon Braket Workshop",
     long_description=long_description,
@@ -23,6 +23,8 @@ setuptools.setup(
         "aws-cdk.aws_iam==1.103.0",
         "aws-cdk.aws_secretsmanager==1.103.0",
         "aws-cdk.aws_s3==1.103.0",
+        "aws-cdk.aws_cloudformation==1.103.0", 
+        "aws_cdk.aws_sagemaker==1.103.0"
     ],
 
     python_requires=">=3.6",

--- a/tests/unit/test_braket_workshop_cdk_stack.py
+++ b/tests/unit/test_braket_workshop_cdk_stack.py
@@ -2,12 +2,12 @@ import json
 import pytest
 
 from aws_cdk import core
-from braket_workshop_cdk.braket_workshop_cdk_stack import BraketWorkshopCdkStack
+from braket_workshop_cdk.braket_workshop_cdk_stack import BraketWorkshopIAMStack
 
 
 def get_template():
     app = core.App()
-    BraketWorkshopCdkStack(app, "braket-workshop-cdk")
+    BraketWorkshopIAMStack(app, "braket-workshop-cdk")
     return json.dumps(app.synth().get_stack("braket-workshop-cdk").template)
 
 


### PR DESCRIPTION
Add another stack to create Braket Notebooks among 3 AWS Regions. 
This feature is enabled with deploy command: 
```
cdk deploy --all
```
instead of 
```
cdk deploy braket-workshop-iam
```