### PR TITLE
Fix method name typo

### DIFF
--- a/braket_workshop_cdk/braket_workshop_cdk_stack.py
+++ b/braket_workshop_cdk/braket_workshop_cdk_stack.py
@@ -220,4 +220,4 @@ class BraketWorkshopIAMStack(core.Stack):
         from distutils.util import strtobool
         disable_qpu = strtobool(self.node.try_get_context("disable_qpu"))
         if disable_qpu: 
-            braket_disable_qpu_policy.attatchToRoles(braket_notebook_role)
+            braket_disable_qpu_policy.attach_to_role(braket_notebook_role)


### PR DESCRIPTION
I assume this method is [`attach_to_role`](https://docs.aws.amazon.com/cdk/api/latest/python/aws_cdk.aws_iam/Policy.html#aws_cdk.aws_iam.Policy.attach_to_role).