### PR TITLE
Fix log IAM policy

### DIFF
--- a/braket_workshop_cdk/braket_workshop_cdk_stack.py
+++ b/braket_workshop_cdk/braket_workshop_cdk_stack.py
@@ -153,7 +153,7 @@ class BraketWorkshopIAMStack(core.Stack):
                 "logs:CreateLogGroup"
             ], 
             resources=[
-                "arn:aws:logs:*::log-group:/aws/sagemaker/*"
+                f"arn:aws:logs:*:{self.account}:log-group:/aws/sagemaker/*"
             ]
         )
         


### PR DESCRIPTION
Writing to CloudWatch logs does not work without specifying account ID in resource ARN.